### PR TITLE
New scripts from unagi-trunk

### DIFF
--- a/bandai_fcg1.ad
+++ b/bandai_fcg1.ad
@@ -1,0 +1,32 @@
+/*
+BANDAI FCG-1, FCG-2
+FCG-1 + Program ROM + Charcter ROM
+	ドラゴンボール 大魔王復活
+	西村京太郎ミステリー ブルートレイン殺人事件 (Irem)
+FCG-2 + Program ROM + Charcter ROM
+	ファミコンジャンプ
+	魁!!男塾
+	名門！第三野球部
+	ドラゴンボール3
+	悪魔くん
+*/
+board <- {
+	mappernum = 16, 
+	cpu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x4000
+	}, 
+	cpu_ram = {
+		size_base = 0x0000, size_max = 0x0000,
+		banksize = 0x2000
+	},
+	ppu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = false
+};
+
+const register_offset = 0x6000;
+dofile("fcg3.ai");

--- a/bandai_karaoke.ad
+++ b/bandai_karaoke.ad
@@ -1,0 +1,61 @@
+/*
+Karaoke Studio by Bandai
+*/
+board <- {
+	mappernum = 188, vram_mirrorfind = false, ppu_ramfind = false,
+	cpu_rom = {
+		size_base = 1 * mega, size_max = 4 * mega,
+		banksize = 0x4000
+	}, 
+	cpu_ram = {
+		size_base = 0x400, size_max = 0x400,
+		banksize = 0x400
+	}, 
+	ppu_rom = {
+		size_base = 0, size_max = 0,
+		banksize = 0x2000
+	}
+};
+
+function dump_mainrom(d, banksize)
+{
+	for(local i = 0; i < 8 - 1; i += 1){
+		local dd = i + 0x10;
+		cpu_write(d, 0xf000 + dd, dd);
+		cpu_read(d, 0x8000, banksize);
+	}
+	cpu_read(d, 0xc000, banksize);
+}
+/*
+page map
+0x00 to 0x0f: subcartridge ROM
+0x10 to 0x17: main PCB ROM data (mirror)
+0x18 to 0x1f: main PCB ROM data
+*/
+function cpu_dump(d, pagesize, banksize)
+{
+	if(pagesize == 8){
+		dump_mainrom(d, banksize);
+	}else{
+/*
+結合型 nes file は先頭から順に main ROM, sub ROM を配置する。
+write register の順番から見ると変。
+*/
+		dump_mainrom(d, banksize);
+		for(local i = 0; i < (pagesize / 2); i += 1){
+			cpu_write(d, 0xc000 + i, i);
+			cpu_read(d, 0x8000, banksize);
+		}
+	}
+}
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	cpu_write(d, 0xc008, [0x08,0x09]);
+	cpu_ramrw(d, 0xf000, 1);
+	cpu_ramrw(d, 0x8000, 1);
+	cpu_write(d, 0xc04a, [0x4a,0x4b]);
+	cpu_ramrw(d, 0x8000, 1);
+	cpu_ramrw(d, 0x6000, banksize - 3);
+}
+

--- a/bandai_lz93d50_x24c01.ag
+++ b/bandai_lz93d50_x24c01.ag
@@ -1,0 +1,95 @@
+/*
+BANDAI FCG-3 + X24C01 style cartridge
+
+SDガンダム外伝 ナイトガンダム物語
+	1990-08-11 B50EEP, LZ93D50+X24C01
+ドラゴンボールZ 強襲！サイヤ人
+	1990-10-27 DRAGON BALLZ, LZ93D50+X24C01
+まじかる☆タルるートくん ファンタスティックワールド
+	1991-03-21 DRAGON BALLZ-B, LZ93D50+X24C01
+まじかる☆タルるートくん2
+	1992-06-19 DRAGON BALLZ-B, LZ93D50+X24C01 ← 24C02 ではない
+*/
+board <- {
+	mappernum = 16, 
+	cpu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x4000
+	}, 
+	cpu_ram = {
+		size_base = 0x0080, size_max = 0x0080,
+		banksize = 0x0080
+	},
+	ppu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = false
+};
+
+const register_offset = 0x8000;
+dofile("lz93d50.ai");
+
+/*
+=====================
+X24C01 frame sequence
+=====================
+<START>[EEPROM address+RW]<A-ACK>[data]<D-ACK><STOP>
+
+<> is 1bit, [] is 8bit, A-ACK is address acknowledge, 
+D-ACK is data acknowledge, R is 1, W is 0
+
+8bit data send MSB to LSB (bit7 to bit0)
+Dragon Ball Z1's program send address LSB to MSB (bug).
+
+slave address does not exist.
+
+--current address read--
+<START>[EEPROM address,R]<A-ACK>[EEPROM data]<D-ACK><STOP>
+
+--sequenctial read--
+<START>[EEPROM address,R]<A-ACK>|[EEPROM data]<D-ACK>|<STOP>
+                                |<- loop any times ->|
+
+--page write---
+|<START>[EEPROM address,W]<A-ACK>|[EEPROM data]<D-ACK>|<STOP>
+|<-     loop A-ACK is H        ->|<- loop 1to4times ->|
+*/
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	local I2C_WRITE = I2C_SEND_L;
+	local I2C_READ = I2C_SEND_H;
+
+	if(mode_is_read(d) == true){
+		//sequential read
+		i2c_address_set(d, 0, I2C_READ);
+		for(local i = 0; i < pagesize * banksize; i++){
+			for(local bit = 0; bit < 8; bit++){
+				cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_H);
+				cpu_write(d, 0x800d, I2C_DIR_READ | I2C_CLOCK_H | I2C_SEND_H);
+				cpu_read_bit_msb(d, 0x6000, 4);
+			}
+			//send ack
+			send_bit(d, I2C_SEND_L);
+		}
+		i2c_stop(d);
+	}else{
+		//page write (4byte)
+		for(local i = 0; i < pagesize * banksize; i+=4){
+			i2c_address_set(d, i, I2C_WRITE);
+			for(local j = 0; j < 4; j++){
+				for(local bit = 0; bit < 8; bit++){
+					local n = I2C_SEND_L;
+					if(cpu_fetch_bit_msb(d) != 0){
+						n = I2C_SEND_H;
+					}
+					send_bit(d, n);
+				}
+				i2c_ack_wait(d);
+			}
+			i2c_stop(d);
+		}
+	}
+}

--- a/bandai_lz93d50_x24c02.ag
+++ b/bandai_lz93d50_x24c02.ag
@@ -1,0 +1,113 @@
+/*
+BANDAI FCG-3 + X24C02 style cartridge
+
+ドラゴンボールZII 激神フリーザ!!
+	1991-08-10, DRAGON BALLZ-B ,LZ93D50+X24C02
+SDガンダム外伝 ナイトガンダム物語2
+	1991-10-12, DRAGON BALLZ-B, LZ93D50+X24C02
+SDガンダム外伝 ナイトガンダム物語3
+	1992-10-23, DRAGON BALLZ-B, LZ93D50+X24C02
+DATACH 本体
+	1992-12-19, BA-BAR, LZ93D50P+X24C02 (Charcter RAM)
+クレヨンしんちゃん
+	1993-08-27, DRAGON BALLZ-B, LZ93D50 (EEPROM なし)
+ろくでなしBLUES
+	1993-10-29, DRAGON BALLZ-B, LZ93D50+X24C02
+*/
+board <- {
+	mappernum = 16, 
+	cpu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x4000
+	}, 
+	cpu_ram = {
+		size_base = 0x0100, size_max = 0x0100,
+		banksize = 0x0100
+	},
+	ppu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = false
+};
+
+const register_offset = 0x8000;
+dofile("lz93d50.ai")
+/*
+=====================
+X24C02 frame sequence
+=====================
+<START>[slave address+RW]<A-ACK>[data]<D-ACK><STOP>
+
+<> is 1bit, [] is 8bit, A-ACK is address acknowledge, 
+D-ACK is data acknowledge, R is 1, W is 0
+
+slave address 6:3 is 4'b0101, fixed
+slave address 2:0 is 3'b000, configurated by PCB
+
+8bit data send MSB to LSB (bit7 to bit0)
+
+--current address set--
+<START>[0x50,W]<A-ACK>[EEPROM address]<D-ACK><STOP>
+
+--current address read--
+<START>[0x50,R]<A-ACK>[EEPROM data]<D-ACK><STOP>
+
+--sequenctial read--
+<START>[0x50,R]<A-ACK>|[EEPROM data]<D-ACK>|<STOP>
+                      |<- loop any times ->|
+
+after read operation, EEPROM address is incremented
+
+--page write---
+|<START>[0x50,W]<A-ACK>|[EEPROM address]<D-ACK>|[EEPROM data]<D-ACK>|<STOP>
+|<- loop A-ACK is H  ->|                       |<- loop 1to4times ->|
+
+After write operation, EEPROM controller is writing data, time is required of 2ms.
+duaring polling, A-ACK returns H. Retry operation.
+
+The page write count is different by the manufacturer.
+X24C01 and X24C02 are designed page write count is 4.
+*/
+function cpu_ram_access(d, pagesize, banksize)
+{
+	local I2C_WRITE = I2C_SEND_L;
+	local I2C_READ = I2C_SEND_H;
+
+	if(mode_is_read(d) == true){
+		//sequenctial read
+		i2c_address_set(d, 0x50, I2C_WRITE);
+		eeprom_address_set(d, 0);
+
+		i2c_address_set(d, 0x50, I2C_READ);
+		for(local i = 0; i < pagesize * banksize; i++){
+			for(local bit = 0; bit < 8; bit++){
+				cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_H);
+				cpu_write(d, 0x800d, I2C_DIR_READ | I2C_CLOCK_H | I2C_SEND_H);
+				cpu_read_bit_msb(d, 0x6000, 4);
+			}
+			//send ack
+			send_bit(d, I2C_SEND_L);
+		}
+		i2c_stop(d);
+	}else{
+		//page write. 4byte
+		for(local i = 0; i < pagesize * banksize; i+=4){
+			i2c_address_set(d, 0x50, I2C_WRITE);
+			eeprom_address_set(d, i);
+			for(local j = 0; j < 4; j++){
+				for(local bit = 0; bit < 8; bit++){
+					local n = I2C_SEND_L;
+					if(cpu_fetch_bit_msb(d) != 0){
+						n = I2C_SEND_H;
+					}
+					send_bit(d, n);
+				}
+				i2c_ack_wait(d);
+			}
+			i2c_stop(d);
+		}
+	}
+
+}

--- a/irem_g101.ad
+++ b/irem_g101.ad
@@ -1,0 +1,88 @@
+/*
+IREM G-101 based cartridge
+
+$8000-$9fff bank#0, switchable or last - 1
+$a000-$bfff bank#1, switchable
+$c000-$dfff bank#2, last - 1 or switchable
+$e000-$ffff 
+note:
+Major League PCB maybe ignore write operation to $9000-$9fff
+$9000-$9fff write register are fixed to bank #2 = last -1
+*/
+
+board <- {
+	mappernum = 32,
+	cpu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x2000
+	},
+	ppu_rom = {
+		size_base = 1 * mega, size_max = 1 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = false
+};
+
+function cpu_dump(d, pagesize, banksize)
+{
+	if(false){
+		cpu_write(d, 0x9000, 0);
+		for(local i = 0; i < pagesize - 2; i += 2){
+			cpu_write(d, 0x8000, i);
+			cpu_write(d, 0xa000, i | 1);
+			cpu_read(d, 0x8000, banksize * 2);
+		}
+		cpu_read(d, 0xc000, banksize);
+		cpu_read(d, 0xe000, banksize);
+	}else{
+		cpu_write(d, 0x9000, 2);
+		for(local i = 0; i < pagesize - 2; i += 2){
+			cpu_write(d, 0x8000, i);
+			cpu_write(d, 0xa000, i | 1);
+			cpu_read(d, 0xc000, banksize);
+			cpu_read(d, 0xa000, banksize);
+		}
+		cpu_read(d, 0x8000, banksize);
+		cpu_read(d, 0xe000, banksize);
+	}
+}
+function ppu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize ; i += 8){
+		for(local j = 0; j < 8; j += 1){
+			cpu_write(d, 0xb000 + j, i + j);
+		}
+		ppu_read(d, 0, banksize * 8);
+	}
+}
+
+function program_initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_write(d, 0x9000, 0);
+	cpu_write(d, 0x8000, 0);
+	cpu_command(d, 0, 0x8000, cpu_banksize);
+	cpu_command(d, 0x02aa, 0xc000, cpu_banksize);
+	cpu_command(d, 0x0555, 0xc000, cpu_banksize);
+	cpu_write(d, 0xb000, [0xa, 0x15, 0]);
+	cpu_command(d, 0x2aaa, 0x0000, ppu_banksize);
+	cpu_command(d, 0x5555, 0x0400, ppu_banksize);
+	cpu_command(d, 0, 0x0800, ppu_banksize);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 1; i += 1){
+		cpu_write(d, 0x8000, i);
+		cpu_program(d, 0x8000, cpu_banksize);
+	}
+	cpu_program(d, 0xc000, cpu_banksize);
+}
+
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	for(local i = start; i < end; i +=4){
+		cpu_write(d, 0xb004, [i, i+1, i+2, i+3]);
+		ppu_program(d, 0x1000, ppu_banksize * 4);
+	}
+}

--- a/lz93d50.ai
+++ b/lz93d50.ai
@@ -1,0 +1,130 @@
+//cpu_dump, ppu_dump 内で同名の関数を呼んではいけない
+function cpu_dump(d, pagesize, banksize)
+{
+	
+	for(local i = 0; i < pagesize - 1; i += 1){
+		cpu_write(d, register_offset + 8, i);
+		cpu_read(d, 0x8000, banksize);
+	}
+	cpu_read(d, 0xc000, banksize);
+}
+
+function ppu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize; i += 8){
+		for(local j = 0; j < 8; j += 1){
+			cpu_write(d, register_offset + j, i + j);
+			ppu_read(d, j * banksize, banksize);
+		}
+	}
+}
+
+function program_initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_write(d, 0x8008, 0x00);
+	cpu_command(d, 0x0000, 0x8000, cpu_banksize);
+	cpu_command(d, 0x02aa, 0xc000, cpu_banksize);
+	cpu_command(d, 0x0555, 0xc000, cpu_banksize);
+	cpu_write(d, 0x8000, [0x0a, 0x15, 0]);
+	ppu_command(d, 0x2aaa, 0, ppu_banksize);
+	ppu_command(d, 0x5555, 0x0400, ppu_banksize);
+	ppu_command(d, 0, 0x0800, ppu_banksize);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 1; i +=1){
+		cpu_write(d, 0x8008, i);
+		cpu_program(d, 0x8000, cpu_banksize);
+	}
+	cpu_program(d, 0xc000, cpu_banksize);
+}
+
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	for(local i = start; i < end; i +=4){
+		cpu_write(d, 0x8004, [i, i+1, i+2, i+3]);
+		ppu_program(d, 0x1000, ppu_banksize * 4);
+	}
+}
+/*
+$800d
+7 data direction 0:FCG3->EEPROM (write), 1:EEPROM->FCG3 (read)
+6 data, FCG3 -> EEPROM
+5 clock
+
+$6000-$7fff
+4 data, EEPROM -> FCG3
+*/
+const I2C_READBIT = 4;
+const I2C_DIRBIT = 7;
+const I2C_WRITEBIT = 6;
+const I2C_CLOCKBIT = 5;
+
+I2C_DIR_READ <- 1 << I2C_DIRBIT;
+I2C_DIR_WRITE <- 0 << I2C_DIRBIT;
+I2C_SEND_H <- 1 << I2C_WRITEBIT;
+I2C_SEND_L <- 0 << I2C_WRITEBIT;
+I2C_CLOCK_H <- 1 << I2C_CLOCKBIT;
+I2C_CLOCK_L <- 0 << I2C_CLOCKBIT;
+
+function i2c_start(d)
+{
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_L);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_H);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_H | I2C_SEND_H);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_H | I2C_SEND_L);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_L);
+}
+
+function i2c_stop(d)
+{
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_L);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_H | I2C_SEND_L);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_H | I2C_SEND_H);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_H);
+	cpu_write(d, 0x800d, I2C_DIR_READ | I2C_CLOCK_L | I2C_SEND_H);
+}
+
+function i2c_ack_wait(d)
+{
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_H);
+	cpu_write(d, 0x800d, I2C_DIR_READ | I2C_CLOCK_H | I2C_SEND_L);
+	local n = cpu_read_register(d, 0x6000, 0);
+	n = n & (1 << I2C_READBIT);
+	return n == 0;
+}
+
+
+function send_bit(d, v)
+{
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | I2C_SEND_L);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_L | v);
+	cpu_write(d, 0x800d, I2C_DIR_WRITE | I2C_CLOCK_H | v);
+}
+
+function i2c_address_set(d, address, rw)
+{
+	do{
+		local a = address;
+		i2c_start(d);
+		for(local i = 0; i < 7; i++){
+			send_bit(d, a & I2C_SEND_H);
+			a = a << 1;
+		}
+		send_bit(d, rw);
+	}while(i2c_ack_wait(d) != true);
+}
+
+function eeprom_address_set(d, address)
+{
+	for(local i = 0; i < 8; i++){
+		local n = I2C_SEND_L;
+		if(address & 0x80){
+			n = I2C_SEND_H;
+		}
+		send_bit(d, n);
+		address = address << 1;
+	}
+	i2c_ack_wait(d);
+}

--- a/namcot_108_3433.ad
+++ b/namcot_108_3433.ad
@@ -1,0 +1,44 @@
+/*
+Namcot 118/119 chip with Charcter ROM A16 wired PPU A12
+
+Quinty
+*/
+board <- {
+	mappernum = 88, vram_mirrorfind = true, ppu_ramfind = false,
+	cpu_rom = {
+		size_base = 0x10000, size_max = 1*mega,
+		banksize = 0x2000
+	},
+	cpu_ram = {
+		size_base = 0, size_max = 0, banksize = 0
+	}
+	ppu_rom = {
+		size_base = 0x20000, size_max = 0x20000,
+		banksize = 0x0400
+	}
+};
+
+function cpu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize - 2; i += 2){
+		cpu_write(d, 0x8000, [6, i, 7, i+1]);
+		cpu_read(d, 0x8000, banksize * 2);
+	}
+	cpu_read(d, 0xc000, banksize * 2);
+}
+
+function ppu_dump(d, pagesize, banksize)
+{
+	local i;
+	//ROM offset 0x00000-0x0ffff can access from PPU address 0x0000-0x0fff
+	for(i = 0; i < (pagesize >> 1); i += 4){
+		cpu_write(d, 0x8000, [0, i, 1, i+2]);
+		ppu_read(d, 0x0000, banksize * 4);
+	}
+	
+	//ROM offset 0x10000-0x1ffff can access from PPU address 0x1000-0x1fff
+	for(; i < pagesize; i += 4){
+		cpu_write(d, 0x8000, [2, i, 3, i+1, 4, i+2, 5, i+3]);
+		ppu_read(d, 0x1000, banksize * 4);
+	}
+}

--- a/namcot_108_34xx_nintendo_derom.ad
+++ b/namcot_108_34xx_nintendo_derom.ad
@@ -1,0 +1,47 @@
+/*
+Namcot 108/109/118/119 chip with generic wiring.
+PCB 3401/34[01]5/34[01]6/34[01]7/3451/3413/3414
+    NES-DEROM/DE1ROM/DRROM
+
+この IC は MMC3 より先に登場し、 MMC3 に仕様が似ている。
+仕様が似ている点で,古いエミュレータでは mapper 4 と定義されている。
+
+古くて曖昧な仕様は Namco IC と MMC3 との明確な区別が再定義され、 mapper
+番号も 206 へ分離された。それにも関わらず Namco のゲームは MMC3 
+(mapper 4)という認識と古い ROM image が消えないのはユーザーにとって
+たいした違いがないからだ。
+
+NAMCOT-MC, NAMCOT-SX で動作確認済み
+*/
+
+board <- {
+	mappernum = 206, vram_mirrorfind = true, ppu_ramfind = false,
+	cpu_rom = {
+		size_base = 0x10000, size_max = 1*mega,
+		banksize = 0x2000
+	},
+	cpu_ram = {
+		size_base = 0, size_max = 0, banksize = 0
+	}
+	ppu_rom = {
+		size_base = 0x8000, size_max = 0x10000,
+		banksize = 0x0400
+	}
+};
+function cpu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize - 2; i += 2){
+		cpu_write(d, 0x8000, [6, i, 7, i+1]);
+		cpu_read(d, 0x8000, banksize * 2);
+	}
+	cpu_read(d, 0xc000, banksize * 2);
+}
+
+function ppu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize; i += 8){
+		cpu_write(d, 0x8000, [0, i, 1, i+2]);
+		cpu_write(d, 0x8000, [2, i+4, 3, i+5, 4, i+6, 5, i+7]);
+		ppu_read(d, 0x0000, banksize * 8);
+	}
+}

--- a/namcot_163.ag
+++ b/namcot_163.ag
@@ -1,0 +1,46 @@
+/*
+Namcot 129/163
+
+No battery, no external RAM:
+  Star Wars (129), Namco Classic, Youkai Douchuki, Final Lap, 
+  Erika to Satoru no Yumebouken, Rolling Thunder, Dragon Ninja, 
+  Mappy Kids, Namco Classic II
+
+Battery-backuped Memory is used by an external RAM:
+  Sangokushi, King of Kings, Juvei Quest,
+  Megami Tensei II, Sangokushi II (uses IRQ)
+
+Battery-backuped Memory is used by an internal RAM:
+  Dokuganryu Masamune, Kaiju Monogatari, Mindseeker, Hydride3, 
+  Famista '90, Battle Fleet
+*/
+board <- {
+	mappernum = 19, 
+	cpu_rom = {
+		size_base = 2 * mega, size_max = 4 * mega,
+		banksize = 0x2000
+	}, 
+	cpu_ram = {
+		size_base = 0x0080, size_max = 0x2000,
+		banksize = 0x2000
+	},
+	ppu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = false
+};
+dofile("namcot_19.ai");
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	if(pagesize == 0){ //internal RAM
+		cpu_write(d, 0xf800, 0x80); //autoinrement on
+		cpu_ramrw(d, 0x4800, 0x80);
+	}else{ //external RAM
+		cpu_write(d, 0xf800, 0x40);
+		cpu_ramrw(d, 0x6000, banksize);
+		cpu_write(d, 0xf800, 0x4f);
+	}
+}

--- a/namcot_175.ae
+++ b/namcot_175.ae
@@ -1,0 +1,34 @@
+/*
+Namcot 175
+
+Wagan Land 2, Famista'91, Family Circuit '91, Chibimaruko chan, 
+Heisei Tensai Bakabon
+
+Family Circuit '91 has Program ROM(4M), Charcter ROM and external 
+Battery Backuped WorkRAM.
+*/
+board <- {
+	mappernum = 19, //210, 
+	cpu_rom = {
+		size_base = 2 * mega, size_max = 4 * mega,
+		banksize = 0x2000
+	}, 
+	cpu_ram = {
+		size_base = 0x0800, size_max = 0x0800,
+		banksize = 0x2000
+	}, 
+	ppu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = true
+};
+dofile("namcot_19.ai");
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	cpu_write(d, 0xc000, 0x01);
+	cpu_ramrw(d, 0x6000, 0x0800);
+	cpu_write(d, 0xc000, 0x00);
+}

--- a/namcot_19.ai
+++ b/namcot_19.ai
@@ -1,0 +1,76 @@
+/*
+iNES mapper #19
+
+Many cartridges uses epoxies for ROM, RAM and mapper. Few cartridges 
+uses discrete parts. Other functions are various though the memory 
+mapping is common. 
+
+The mistake of an old document is an etymology of 'namcot 106'. I have
+seen mapper IC with 163 (well known chip), 129, 175 and 340 for #19. 
+I have never seen labeled IC with '106'. 
+'106' is informal virtual name, and the relic of old emulators. 
+*/
+function cpu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize - 2; i += 2){
+		cpu_write(d, 0xe000, i);
+		cpu_write(d, 0xe800, i | 1);
+		cpu_read(d, 0x8000, banksize * 2);
+	}
+	cpu_write(d, 0xf000, 0x3e);
+	cpu_read(d, 0xc000, banksize * 2);
+}
+
+function ppu_dump(d, pagesize, banksize)
+{
+	cpu_write(d, 0xe800, 0xe0);
+	for(local i = 0; i < pagesize; i += 8){
+		local address = 0x8000;
+		for(local j = 0; j < 8; j++){
+			cpu_write(d, address, i | j);
+			address += 0x0800;
+		}
+		ppu_read(d, 0, banksize * 8);
+	}
+}
+
+function program_initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_command(d, 0x0000, 0xa000, cpu_banksize);
+	cpu_command(d, 0x2aaa, 0x8000, cpu_banksize);
+	cpu_command(d, 0x5555, 0xa000, cpu_banksize);
+	cpu_write(d, 0xe000, 0x41);
+	cpu_write(d, 0xe800, 0xe2);
+
+	ppu_command(d, 0x0000, 0x0000, ppu_banksize);
+	ppu_command(d, 0x2aaa, 0x0400, ppu_banksize);
+	ppu_command(d, 0x5555, 0x0800, ppu_banksize);
+	cpu_write(d, 0x8000, 0x00);
+	cpu_write(d, 0x8800, 0x0a);
+	cpu_write(d, 0x9000, 0x15);
+	//map 0x2000-0x2fff is RAM
+	cpu_write(d, 0xc000, 0xe0);
+	cpu_write(d, 0xc800, 0xe0);
+	cpu_write(d, 0xd000, 0xe1);
+	cpu_write(d, 0xd800, 0xe1);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 1; i += 1){
+		cpu_write(d, 0xf000, i | 0xe0);
+		cpu_program(d, 0xc000, cpu_banksize);
+	}
+	cpu_program(d, 0xe000, cpu_banksize)
+}
+
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	for(local i = start; i < end; i += 4){
+		cpu_write(d, 0xa000, i);
+		cpu_write(d, 0xa800, i | 1);
+		cpu_write(d, 0xb000, i | 2);
+		cpu_write(d, 0xb800, i | 3);
+		ppu_program(d, 0x1000, ppu_banksize * 4);
+	}
+}

--- a/namcot_340.ad
+++ b/namcot_340.ad
@@ -1,0 +1,24 @@
+/*
+Namcot 340
+
+Splatter House, Top Striker, Famista '92, Dream Master, 
+Wagan Land3, Famista '93, Famista '94
+*/
+board <- {
+	mappernum = 19, //210, 
+	cpu_rom = {
+		size_base = 2 * mega, size_max = 4 * mega,
+		banksize = 0x2000
+	}, 
+	cpu_ram = {
+		size_base = 0x0800, size_max = 0x0800,
+		banksize = 0x2000
+	}, 
+	ppu_rom = {
+		size_base = 2 * mega, size_max = 2 * mega,
+		banksize = 0x0400
+	},
+	ppu_ramfind = false,
+	vram_mirrorfind = false
+};
+dofile("namcot_19.ai");

--- a/nintendo_mmc4_fkrom.ae
+++ b/nintendo_mmc4_fkrom.ae
@@ -1,0 +1,83 @@
+/*
+HVC-2I Fire Emblem Gaiden
+command line option
+./anago d22 mmc4_fkrom.ae hvc_2i.nes b
+*/
+board <- {
+	mappernum = 10, vram_mirrorfind = false, ppu_ramfind = false,
+	cpu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x4000,
+	}, 
+	cpu_ram = {
+		size_base = 0x2000, size_max = 0x2000,
+		banksize = 0x2000,
+	},
+	ppu_rom = {
+		size_base = 0x10000, size_max = 1 * mega,
+		banksize = 0x1000
+	}
+};
+
+/*
+[cpu memmorymap - read]
+$6000-$7fff SRAM (battery backuped, optional)
+$8000-$bfff program ROM bank #0
+$c000-$ffff program ROM bank #1 (fixed)
+
+[cpu memmorymap - write]
+$a000-$afff program ROM bank register #0
+$b000-$bfff charcter ROM bank register #0
+$c000-$cfff charcter ROM bank register #1
+$d000-$dfff charcter ROM bank register #2
+$d000-$dfff charcter ROM bank register #3
+
+[ppu memorymap - read]
+0x0000-0x0fff charcter ROM bank #A (#0 or #1)
+0x0fd0-0x0fdf charcter ROM bank register switch to #0
+0x0fe0-0x0fef charcter ROM bank register switch to #1
+0x1000-0x1fff charcter ROM bank #B (#2 or #3)
+0x1fd0-0x1fdf charcter ROM bank register switch to #2
+0x1fe0-0x1fef charcter ROM bank register switch to #3
+*/
+function cpu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize - 1; i += 1){
+		cpu_write(d, 0xa000, i);
+		cpu_read(d, 0x8000, banksize);
+	}
+	cpu_read(d, 0xc000, banksize);
+}
+
+/*
+PPU の read 途中にバンクレジスタが切り替わるらしいので下記の処理で
+同じデータを得るようにする。
+PPU address      register
+0x0000-0x0fdf -> #0
+0x0fe0-0x0fff -> #1
+0x1000-0x1fdf -> #2
+0x1fe0-0x1fff -> #3
+
+ppu_read 前に #0 + #1 , #2 + #3 の内容は同じにしておく。
+*/
+function ppu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize; i += 2){
+		ppu_read(d, 0x0fd0, 0);
+		cpu_write(d, 0xb000, i);
+		ppu_read(d, 0x0fe0, 0);
+		cpu_write(d, 0xc000, i);
+
+		ppu_read(d, 0x1fd0, 0);
+		cpu_write(d, 0xd000, i + 1);
+		ppu_read(d, 0x1fe0, 0);
+		cpu_write(d, 0xe000, i + 1);
+
+		ppu_read(d, 0, banksize * 2);
+	}
+}
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	cpu_ramrw(d, 0x6000, banksize);
+}

--- a/sunsoft-4.ae
+++ b/sunsoft-4.ae
@@ -1,0 +1,63 @@
+board <- {
+	mappernum = 68, ppu_ramfind = false, vram_mirrorfind = false,
+	cpu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x4000
+	},
+	cpu_ram = {
+		size_base = 0x2000, size_max = 0x2000, banksize = 0x2000
+	},
+	ppu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x0800
+	}
+};
+
+function cpu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize - 1; i += 1){
+		cpu_write(d, 0xf000, i);
+		cpu_read(d, 0x8000, banksize);
+	}
+	cpu_read(d, 0xc000, banksize);
+}
+
+/*
+After Burner CRC32 list
+0x88f202f0 Program ROM
+0x10935d10 Charcter ROM #0
+0x0bc56f7a Charcter ROM #1
+0xa75cb06d Charcter ROM #0+#1
+0xf2ce3641 total
+*/
+function ppu_dump(d, pagesize, banksize)
+{
+	//dump uses 0x0000-0x1fff
+/*	for(local i = 0; i < pagesize; i += 4){
+		cpu_write(d, 0x8000, i);
+		cpu_write(d, 0x9000, i | 1);
+		cpu_write(d, 0xa000, i | 2);
+		cpu_write(d, 0xb000, i | 3);
+		ppu_read(d, 0, banksize * 4);
+	}
+	//dump uses 0x2000-0x27ff*/
+/*	cpu_write(d, 0xe000, 0x10);
+	for(local i = 0; i < pagesize*2; i += 2){
+		cpu_write(d, 0xc000, i);
+		cpu_write(d, 0xd000, i | 1);
+		ppu_read(d, 0x2000, banksize);
+	}*/
+	//dump uses 0x2000-0x23ff*/
+	cpu_write(d, 0xe000, 0x13);
+	for(local i = 0; i < pagesize*2; i += 1){
+		cpu_write(d, 0xd000, i);
+		ppu_read(d, 0x2000, 0x400);
+	}
+}
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	cpu_write(d, 0xf000, 0x10);
+	cpu_ramrw(d, 0x6000, banksize);
+	cpu_write(d, 0xf000, 0);
+}

--- a/sunsoft-4.ag
+++ b/sunsoft-4.ag
@@ -1,0 +1,131 @@
+board <- {
+	mappernum = 68, ppu_ramfind = false, vram_mirrorfind = false,
+	cpu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x4000
+	},
+	cpu_ram = {
+		size_base = 0x2000, size_max = 0x2000, banksize = 0x2000
+	},
+	ppu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x0800
+	}
+};
+
+/*
+SUNSOFT-4 manages, banksize:0x4000, pagesize:0x10
+[Nantetatte Baseball]
+page 0 to 7:
+uses subcartridge + SUNSOFT-6 controller
+page 8 to F:
+main PCB ROM data, data size is 0x20000
+
+[other games] 
+ROM size is 0x20000, page 0 to 7 and page 8 to f are same data (mirrored).
+*/
+function cpu_dump(d, pagesize, banksize)
+{
+	local i;
+	if(pagesize == 8){
+		i = 8;
+		pagesize += 8;
+	}else{
+		i = 0;
+	}
+	//page 0 to 7 uses via Nanntettate! Baseball Subcartridge
+	for(; i < 8; i += 1){
+		cpu_write(d, 0xf000, i); //set page and enable SUNSOFT-6 (disable Workram)
+		cpu_write(d, 0x6000, 0); //active ROM
+		cpu_read(d, 0x8000, banksize);
+	}
+	//page 8 to 0xe uses normal ROM
+	for(; i < pagesize - 1; i += 1){
+		cpu_write(d, 0xf000, i);
+		cpu_read(d, 0x8000, banksize);
+	}
+	cpu_read(d, 0xc000, banksize);
+}
+
+/*
+SUNSOFT-4 can map Charcter ROM to nametable area.
+
+Charcter data (0x0000 to 0x1fff) banksize is 0x0800
+Nametable data (0x2000 to 0x2fff) banksize is 0x0400
+
+Charcter data
+A[17:11] = reg[6:0]
+A[10:0] = PPU A[10:0]
+
+Nametable data
+A[17] = 1
+A[16:10] = reg[6:0]
+A[9:0] = PPU A[9:0]
+
+After Burner CRC32 list
+0x88f202f0 Program ROM
+0x10935d10 Charcter ROM #0
+0x0bc56f7a Charcter ROM #1
+0xa75cb06d Charcter ROM #0+#1
+0xf2ce3641 total
+*/
+function ppu_dump(d, pagesize, banksize)
+{
+	for(local i = 0; i < pagesize; i += 4){
+		cpu_write(d, 0x8000, i);
+		cpu_write(d, 0x9000, i | 1);
+		cpu_write(d, 0xa000, i | 2);
+		cpu_write(d, 0xb000, i | 3);
+		ppu_read(d, 0, banksize * 4);
+	}
+}
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	cpu_write(d, 0xf000, 0x10); //enable Workram, disable SUNSOFT-6
+	cpu_ramrw(d, 0x6000, banksize);
+	cpu_write(d, 0xf000, 0);
+}
+
+/*
+SUNSOFT-4 has single switchable CPU bank. flash memory program address bit can uses A10:0 type.
+[CPU]
+$8000-$ffff -> programming area
+
+[PPU]
+0x0000-0x07ff -> 0x02800-0x02fff, uses 0x2aaa
+0x0800-0x0fff -> 0x05000-0x05800, uses 0x5555
+0x1000-0x17ff -> ID area (reserved)
+0x1800-0x1fff -> programming area
+*/
+function program_initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_command(d, 0x0000, 0x8000, cpu_banksize);
+	cpu_command(d, 0x2aaa, 0x8000, cpu_banksize);
+	cpu_command(d, 0x5555, 0xc000, cpu_banksize);
+	cpu_write(d, 0xf000, 0); //disable Workram
+
+	ppu_command(d, 0x2aaa, 0x0000, ppu_banksize);
+	cpu_write(d, 0x8000, 0x05);
+	ppu_command(d, 0x5555, 0x0800, ppu_banksize);
+	cpu_write(d, 0x9000, 0x0a);
+	ppu_command(d, 0x0000, 0x1000, ppu_banksize);
+	cpu_write(d, 0xa000, 0);
+}
+
+function cpu_transfer(d, start, end, banksize)
+{
+	for(local i = start; i < end - 1; i += 1){
+		cpu_write(d, 0xf000, i);
+		cpu_program(d, 0x8000, banksize);
+	}
+	cpu_program(d, 0xc000, banksize)
+}
+
+function ppu_transfer(d, start, end, banksize)
+{
+	for(local i = start; i < end; i += 1){
+		cpu_write(d, 0xb000, i);
+		ppu_program(d, 0x1800, banksize);
+	}
+}

--- a/sunsoft-4s.ad
+++ b/sunsoft-4s.ad
@@ -1,0 +1,23 @@
+board <- {
+	mappernum = 68, ppu_ramfind = false, vram_mirrorfind = false,
+	cpu_rom = {
+		size_base = 0x4000, size_max = 2 * mega,
+		banksize = 0x4000
+	},
+	cpu_ram = {
+		size_base = 0x2000, size_max = 0x2000, banksize = 0x2000
+	},
+	ppu_rom = {
+		size_base = 0, size_max = 0,
+		banksize = 0x0800
+	}
+};
+
+function cpu_dump(d, pagesize, banksize)
+{
+	cpu_write(d, 0xf000, 7);
+	cpu_write(d, 0x6000, 0x0d);
+//	cpu_write(d, 0x6000, 0xb0);
+	cpu_read(d, 0x8000, 0x2000);
+	cpu_read(d, 0xa000, 0x2000);
+}

--- a/sunsoft_fme.ad
+++ b/sunsoft_fme.ad
@@ -1,0 +1,155 @@
+board <- {
+	mappernum = 69, vram_mirrorfind = false, ppu_ramfind = false,
+	cpu_rom = {
+		size_base = 1 * mega, size_max = 2 * mega,
+		banksize = 0x2000
+	}, cpu_ram = {
+		size_base = 0x2000, size_max = 0x2000, 
+		banksize = 0x2000
+	}, ppu_rom = {
+		size_base = 1 * mega, size_max = 2 *mega,
+		banksize = 0x0400
+	}
+};
+
+/*
+SUNSOFT-5A, SUNSOFT-5B, FME-7
+[CPU writemap]
+$6000-$7fff 7:0 RAM data (if RAM is enabled)
+$8000-$9fff 3:0 memory register address
+$a000-$bfff 7:0 memory register data
+$c000-$dfff 3:0 audio register address
+$e000-$ffff 7:0 audio register data
+
+[CPU readmap]
+$6000-$7fff 7:0 Program ROM bank #0 or RAM
+$8000-$9fff 7:0 Program ROM bank #1
+$a000-$bfff 7:0 Program ROM bank #2
+$c000-$dfff 7:0 Program ROM bank #3
+$e000-$ffff 7:0 Program ROM bank #4 (fixed to bottom page)
+
+[PPU readmap] (PPU write map is undefined)
+0x0000-0x03ff Charcter ROM bank #0|0x1000-0x13ff Charcter ROM bank #4
+0x0400-0x07ff Charcter ROM bank #1|0x1400-0x17ff Charcter ROM bank #5
+0x0800-0x0bff Charcter ROM bank #2|0x1800-0x1bff Charcter ROM bank #6
+0x0c00-0x0fff Charcter ROM bank #3|0x1c00-0x1fff Charcter ROM bank #7
+
+[FME-7 memory register]
+adr bit assignments
+-------------------------
+0-7 7:0 Charcter ROM bank #0 to #7
+8   7   RAM enable bit 0:disable 1:enable
+    6   memory select at $6000-$7fff 0:ROM 1:RAM
+    4:0 CPU ROM page for bank #0
+9-b 4:0 CPU ROM page for bank #1 to #3
+c   1:0 PPU area VRAM control
+d   7   φ2 counter decrement 0:disable 1:enable
+    0   φ2 counter overflow IRQ 0:disable 1:enable
+e   7:0 φ2 counter value bit7:0
+f   7:0 φ2 counter value bit15:8
+
+address 8, bit7:6 behave on FME-7
+00 enabled ROM
+01 disabled ROM and RAM
+10 disabled ROM and RAM
+11 enabled RAM
+
+audio register
+(not analysed yet)
+
+*/
+function sunsoft5_write(d, register_address, data)
+{
+	cpu_write(d, 0x8000, register_address);
+	cpu_write(d, 0xa000, data);
+}
+
+function cpu_dump(d, pagesize, banksize)
+{
+/*
+	//dump ROM data via $6000-$7fff
+	for(local i = 0; i < pagesize; i++){
+		sunsoft5_write(d, 8, i);
+		cpu_read(d, 0x6000, banksize);
+	}
+*/
+	for(local i = 0; i < pagesize - 1; i++){
+		sunsoft5_write(d, 9, i);
+		cpu_read(d, 0x8000, banksize);
+	}
+	cpu_read(d, 0xe000, banksize);
+}
+
+function ppu_dump(d, pagesize, banksize)
+{
+	local mul = 8;
+	for(local i = 0; i < pagesize; i+= mul){
+		for(local j = 0; j < mul; j++){
+			sunsoft5_write(d, j, i + j);
+		}
+		ppu_read(d, 0, banksize * mul);
+	}
+}
+
+function cpu_ram_access(d, pagesize, banksize)
+{
+	sunsoft5_write(d, 8, 0xc0);
+	cpu_ramrw(d, 0x6000, banksize);
+	cpu_write(d, 0xa000, 0x00);
+}
+
+/*
+CPU memory bank
+cpu address|rom address    |page|task
+$8000-$9fff|0x02000-0x03fff|1   |write 0x2aaa
+$a000-$bfff|0x04000-0x05fff|2   |write 0x5555
+$c000-$dfff|n * 0x2000     |n   |program area
+$e000-$ffff|0x3c000-0x3ffff|fix |program last page
+
+PPU memory bank
+ppu address  |rom address    |page|task
+0x0000-0x03ff|0x02800-0x02fff|0x0a|write 0x2aaa
+0x0400-0x07ff|0x05000-0x057ff|0x14|write 0x5555
+0x0800-0x0fff|未使用
+0x1000-0x1fff|n * 0x1000     |n   |program area
+*/
+function program_initalize(d, cpu_banksize, ppu_banksize)
+{
+	sunsoft5_write(d, 8, 0x40); //disable W-RAM
+
+	cpu_command(d, 0x2aaa, 0xe000, cpu_banksize);
+	cpu_command(d, 0x5555, 0xe000, cpu_banksize);
+	sunsoft5_write(d, 0xa,1);
+	sunsoft5_write(d, 0xb,2);
+
+	ppu_command(d, 0x2aaa, 0x1000, ppu_banksize);
+	ppu_command(d, 0x5555, 0x1400, ppu_banksize);
+	ppu_command(d, 0x0000, 0x1800, ppu_banksize);
+	sunsoft5_write(d, 4, 0x0a);
+	sunsoft5_write(d, 5, 0x15);
+	sunsoft5_write(d, 6, 0);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 1; i += 1){
+		sunsoft5_write(d, 0xb, 3);
+		cpu_program(d, 0x8000, cpu_banksize);
+	}
+	cpu_program(d, 0xe000, cpu_banksize);
+}
+
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+/*	local mul = 1;
+	for(local i = start; i < end; i += mul){
+		for(local j = 0; j < mul; j++){
+			sunsoft5_write(d, j, i + j);
+		}
+		ppu_program(d, 0x0000, ppu_banksize * mul);
+	}*/
+	for(local i = start; i < end; i += 1){
+		sunsoft5_write(d, 4, i);
+		ppu_program(d, 0x1000, ppu_banksize);
+	}
+}


### PR DESCRIPTION
These scripts are all from [the official Sourceforge repo](http://sourceforge.jp/projects/unagi/scm/svn/tree/head/client/trunk/anago/), but haven't yet made it in to an official release (the latest release seems to be from March 2010).

As they are "official", I did not change the names at all.

Do these scripts belong here, or would it be better to maybe just add a link to the Sourceforge page where they can be found?
