### PR TITLE
Gnrom updated with romsize variable values from mmc3.ad, let me dump …

### DIFF
--- a/_gnrom.ad
+++ b/_gnrom.ad
@@ -5,12 +5,8 @@ http://tuxnes.sourceforge.net/mappers-0.80.txt
 
 board <- {
   mappernum = 66,
-  cpu_rom = {
-    size_base = 0x10000, size_max = 2 * mega, banksize = 0x8000
-  },
-  ppu_rom = {
-    size_base = 0x4000, size_max = 0x8000, banksize = 0x2000
-  },
+  cpu_romsize = 2 * mega, cpu_banksize = 0x8000,
+  ppu_romsize = 2 * mega, ppu_banksize = 0x2000,
   ppu_ramfind = false, vram_mirrorfind = true
 };
 


### PR DESCRIPTION
…Super Mario Bros. / Duck Hunt what appears to be correctly. Can't seem to find anago version number, but it's the exe from 7/27/2013 from infiniteneslives' kazzo zip (appears to be inside unagi's command line v60 windows client too). Likely needs more formal testing, but this at least got a mapper 66 game dumping without visual or audio issues where previously that was not the case.