### PR TITLE
New Scripts & Wiki Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Related links:
 
 * http://nesdev.parodius.com/bbs/viewtopic.php?t=7912
 * http://sourceforge.jp/projects/unagi/releases/49771
+* [how to write mapper scripts](http://unagi.osdn.jp/cgi-bin/hiki/hiki.cgi?how+to+describe+mapper+scripts)
 
 Scripts here are all prefixed with an underscore (_) to make them stand out
 from those scripts that come with the tool.

--- a/_Sunsoft5.ad
+++ b/_Sunsoft5.ad
@@ -1,0 +1,75 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-189.html
+// とsunsoft5(マッパ６９）
+/*
+SUNSOFT 5A[PRG:MAX 2M]
+バットマン
+
+SUNSOFT 5B[拡張音源]
+ギミック
+
+FME-7[PRG:MAX 4M] & SUNSOFT 5B[拡張音源]?
+炎の闘球児ドッジ弾平
+
+FME-7+BB[PRG:MAX 4M]
+バーコードワールド
+炎の闘球児ドッジ弾平2
+
+CPU Memmory Bank
+ cpu address|rom address    |page|task
+ $8000-$9fff|0x02000-0x03fff|1   |write 0x2aaa
+ $a000-$bfff|0x04000-0x05fff|2   |write 0x5555
+ $c000-$dfff|0x02000*n      |n   |write area
+ $e000-$ffff|末尾           |fix |
+
+PPU Memmory Bank
+ ppu address|rom address    |page|task
+ $0000-$03ff|0x02800-0x02bff|0x0a|write 0x02aaa
+ $0400-$07ff|0x05400-0x057ff|0x15|write 0x05555
+ $0800-$0bff|未使用
+ $0c00-$0fff|未使用
+ $1000-$1FFF|0x1000*n       |n   |write area
+*/
+board <- {
+	mappernum = 69, vram_mirrorfind = false,
+	cpu = {banksize = 0x2000, maxsize = 4 * mega},
+	ppu = {banksize = 0x0400, maxsize = 2 * mega},
+};
+function initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_command(d, 0x2aaa, 0x8000, cpu_banksize);
+	cpu_command(d, 0x5555, 0xa000, cpu_banksize);
+	cpu_write(d, 0x8000, 0x09);
+	cpu_write(d, 0xa000, 1);
+	cpu_write(d, 0x8000, 0x0a);
+	cpu_write(d, 0xa000, 2);
+
+	ppu_command(d, 0x2aaa, 0x0000, ppu_banksize);
+	ppu_command(d, 0x5555, 0x0400, ppu_banksize);
+	cpu_write(d, 0x8000, 0);
+	cpu_write(d, 0xa000, 0x0a);
+	cpu_write(d, 0x8000, 1);
+	cpu_write(d, 0xa000, 0x15);
+}
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 1; i += 1){
+		cpu_write(d, 0x8000, 0x0b);
+		cpu_write(d, 0xa000, i);
+		cpu_program(d, 0xc000, cpu_banksize);
+	}
+	cpu_program(d, 0xe000, cpu_banksize)
+}
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	for(local i = start; i < end; i += 4){
+		cpu_write(d, 0x8000, 4);
+		cpu_write(d, 0xa000, i);
+		cpu_write(d, 0x8000, 5);
+		cpu_write(d, 0xa000, i | 1);
+		cpu_write(d, 0x8000, 6);
+		cpu_write(d, 0xa000, i | 2);
+		cpu_write(d, 0x8000, 7);
+		cpu_write(d, 0xa000, i | 3);
+		ppu_program(d, 0x1000, ppu_banksize * 4);
+	}
+}

--- a/_bandai_70.ud
+++ b/_bandai_70.ud
@@ -1,0 +1,22 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-203.html
+board <- {
+  mappernum = 70,
+  cpu_romsize = 1 * mega, cpu_banksize = 0x4000,
+  ppu_romsize = 1 * mega, ppu_banksize = 0x2000,
+  ppu_ramfind = true, vram_mirrorfind = false
+};
+
+function cpu_dump(d, pagesize, banksize){
+  for(local i = 0; i < pagesize - 1 ; i++){
+    cpu_write(d, 0xc000, i << 4);
+    cpu_read(d, 0x8000, banksize);
+  }
+  cpu_read(d, 0xc000, banksize);
+}
+
+function ppu_dump(d, pagesize, banksize){
+  for(local i = 0; i < pagesize; i++){
+    cpu_write(d, 0xc000, i);
+    ppu_read(d, 0, banksize);
+  }
+}

--- a/_lz93d50#16.ad
+++ b/_lz93d50#16.ad
@@ -1,0 +1,48 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-210.html
+// Bandai#16用吸い出しスクリプト
+/*
+Bandai#16(#159?)
+
+LZ93D50+24C01(1Kbit EEPROM) #159?
+LZ93D50+24C02(2Kbit EEPROM) #16 ?
+
+FCG-2|FCG-1|LZ93D50 カセットのチップによって記述変更？
+6000h|7FF0h|8000h Select 1K VROM at PPU 0000h-03FFh
+6001h|7FF1h|8001h Select 1K VROM at PPU 0400h-07FFh
+6002h|7FF2h|8002h Select 1K VROM at PPU 0800h-0BFFh
+6003h|7FF3h|8003h Select 1K VROM at PPU 0C00h-0FFFh
+6004h|7FF4h|8004h Select 1K VROM at PPU 1000h-13FFh
+6005h|7FF5h|8005h Select 1K VROM at PPU 1400h-17FFh
+6006h|7FF6h|8006h Select 1K VROM at PPU 1800h-1BFFh
+6007h|7FF7h|8007h Select 1K VROM at PPU 1C00h-1FFFh
+6008h|7FF8h|8008h Select 16K ROM at 8000h-BFFFh (initially 1st bank)
+N/A Fixed 16K ROM at C000h-FFFFh (always last bank)
+*/
+board <- {
+  mappernum = 16,
+  cpu_romsize = 2 * mega, cpu_banksize = 0x4000,
+  ppu_romsize = 2 * mega, ppu_banksize = 0x0400,
+  ppu_ramfind = true, vram_mirrorfind = false
+};
+
+function cpu_dump(d, pagesize, banksize) {
+  for(local i = 0; i < pagesize - 1; i +=1){
+    cpu_write(d, 0x8008, i);
+    cpu_read(d, 0x8000, banksize);
+  }
+  cpu_read(d, 0xc000, banksize);
+}
+
+function ppu_dump(d, pagesize, banksize){
+  for(local i = 0; i < pagesize; i+=8){
+    cpu_write(d, 0x8000, i);
+    cpu_write(d, 0x8001, i | 1);
+    cpu_write(d, 0x8002, i | 2);
+    cpu_write(d, 0x8003, i | 3);
+    cpu_write(d, 0x8004, i | 4);
+    cpu_write(d, 0x8005, i | 5);
+    cpu_write(d, 0x8006, i | 6);
+    cpu_write(d, 0x8007, i | 7);
+    ppu_read(d, 0x0000, banksize * 8);
+  }
+}

--- a/_lz93d50#16write.ad
+++ b/_lz93d50#16write.ad
@@ -1,0 +1,69 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-210.html
+// Bandai#16用吸い出しスクリプト
+/*
+Bandai#16 FLASH MEMORY WRITE
+
+LZ93D50+24C01(1Kbit EEPROM) #159?
+LZ93D50+24C02(2Kbit EEPROM) #16 ?
+
+FCG-2|FCG-1|LZ93D50 作成したカセットのチップによって変更？
+6000h|7FF0h|8000h Select 1K VROM at PPU 0000h-03FFh
+6001h|7FF1h|8001h Select 1K VROM at PPU 0400h-07FFh
+6002h|7FF2h|8002h Select 1K VROM at PPU 0800h-0BFFh
+6003h|7FF3h|8003h Select 1K VROM at PPU 0C00h-0FFFh
+6004h|7FF4h|8004h Select 1K VROM at PPU 1000h-13FFh
+6005h|7FF5h|8005h Select 1K VROM at PPU 1400h-17FFh
+6006h|7FF6h|8006h Select 1K VROM at PPU 1800h-1BFFh
+6007h|7FF7h|8007h Select 1K VROM at PPU 1C00h-1FFFh
+6008h|7FF8h|8008h Select 16K ROM at 8000h-BFFFh (initially 1st bank)
+N/A Fixed 16K ROM at C000h-FFFFh (always last bank)
+
+CPU Memmory Bank
+cpu address|rom address |page|task
+$8000-$bfff|0x04000*n |n |write area
+$c000-$ffff|末尾 |fix |boot area & write 0x02aa or 0x0555
+
+PPU Memmory Bank
+ppu address|rom address |page|task
+$0000-$03ff|0x02800-0x02bff|0x0a|write 0x02aaa
+$0400-$07ff|0x05400-0x057ff|0x15|write 0x05555
+$0800-$0bff|未使用 | |
+$0c00-$03ff|未使用 | |
+$1000-$1FFF|0x1000*n |n |write area
+*/
+board <- {
+  mappernum = 16, vram_mirrorfind = false,
+  cpu = {banksize = 0x4000, maxsize = 2 * mega},
+  ppu = {banksize = 0x0400, maxsize = 2 * mega},
+};
+
+function initalize(d, cpu_banksize, ppu_banksize){
+  cpu_command(d, 0x02aa, 0xc000, cpu_banksize);
+  cpu_command(d, 0x0555, 0xc000, cpu_banksize);
+
+  ppu_command(d, 0x2aaa, 0, ppu_banksize);
+  ppu_command(d, 0x5555, 0x0400, ppu_banksize);
+
+  cpu_write(d, 0x8000, 0x0a);
+  cpu_write(d, 0x8001, 0x15);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize){
+  for(local i = start; i < end; i += 1){
+    cpu_write(d, 0x8008, i);
+    cpu_program(d, 0x8000, cpu_banksize);
+  }
+  /*
+  cpu_program(d, 0xc000, cpu_banksize);
+  */
+}
+
+function ppu_transfer(d, start, end, ppu_banksize){
+  for(local i = start; i < end; i += 4){
+    cpu_write(d, 0x8004, i);
+    cpu_write(d, 0x8005, i | 1);
+    cpu_write(d, 0x8006, i | 2);
+    cpu_write(d, 0x8007, i | 3);
+    ppu_program(d, 0x1000, ppu_banksize * 4);
+  }
+}

--- a/_mapper_185.ad
+++ b/_mapper_185.ad
@@ -1,0 +1,19 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-195.html?all
+board <- {
+  mappernum = 185,
+  cpu_romsize = 0x8000, cpu_banksize = 0x8000,
+  ppu_romsize = 0x2000, ppu_banksize = 0x2000,
+  ppu_ramfind = false, vram_mirrorfind = true
+};
+
+function cpu_dump(d, pagesize, banksize) {
+  cpu_read(d, 0x8000, 0x4000);
+  cpu_read(d, 0xc000, 0x4000);
+}
+
+function ppu_dump(d, pagesize, banksize) {
+  for(local i = 0; i < pagesize; i++){
+    cpu_write(d, 0x8000, i);
+    ppu_read(d, 0, banksize);
+  }
+}

--- a/_mdc5.af
+++ b/_mdc5.af
@@ -1,0 +1,53 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-224.html
+/*
+MDC5書き込みスクリプト
+
+SRAM 初期化
+ST + SEL を押しながら電源を入れて SEL を押す
+
+disk side change
+下記の入力があったら disk を交換したとする
+SEL + A,A,A: change side A
+SEL + B,B,B: change side B
+SEL + ST,ST,ST: swap disk 前編/後編
+
+*/
+board <- {
+  mappernum = 5, 
+  cpu_rom = {
+    size_base = 2 * mega, size_max = 8 * mega,
+    banksize = 0x2000
+  },
+  cpu_ram = {
+    size_base = 0x2000, size_max = 0x8000,
+    banksize = 0x2000
+  },
+  ppu_rom = {
+    size_base = 2 * mega, size_max = 8 * mega,
+    banksize = 0x0800
+  },
+  ppu_ramfind = true, vram_mirrorfind = false
+};
+
+function program_initalize(d, cpu_banksize, ppu_banksize) {
+  cpu_command(d, 0x0000, 0x8000, cpu_banksize);
+  cpu_command(d, 0x2aaa, 0xa000, cpu_banksize);
+  cpu_command(d, 0x5555, 0xc000, 0x4000);
+  cpu_write(d, 0x5100, 3);
+  cpu_write(d, 0x5113, 0);
+  cpu_write(d, 0x5114, 0x80);
+  cpu_write(d, 0x5115, 0x81);
+  cpu_write(d, 0x5116, 0x82);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize) {
+  for(local i = start; i < end - 1; i += 1){
+    cpu_write(d, 0x5114, 0x80 | i);
+    cpu_program(d, 0x8000, cpu_banksize);
+  }
+  //$e000- は書き込みが安定しないので末尾 page として $7f を指定する。
+  cpu_write(d, 0x5114, 0x80 | 0x7f);
+  cpu_program(d, 0x8000, cpu_banksize);
+}
+
+function ppu_transfer(d, start, end, ppu_banksize) {}

--- a/_namcot163.ad
+++ b/_namcot163.ad
@@ -1,0 +1,74 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-189.html
+// namcot163(マッパ１９）
+/*
+namcot163 #19 FLASH MEMORY WRITE
+
+ 8000h-87FFh  Select 1K VROM at PPU 0000h-03FFh (with E800h/Bit6)
+ 8800h-8FFFh  Select 1K VROM at PPU 0400h-07FFh ("")
+ 9000h-97FFh  Select 1K VROM at PPU 0800h-0BFFh ("")
+ 9800h-9FFFh  Select 1K VROM at PPU 0C00h-0FFFh ("")
+ A000h-A7FFh  Select 1K VROM at PPU 1000h-13FFh (with E800h/Bit7)
+ A800h-AFFFh  Select 1K VROM at PPU 1400h-17FFh ("")
+ B000h-B7FFh  Select 1K VROM at PPU 1800h-1BFFh ("")
+ B800h-BFFFh  Select 1K VROM at PPU 1C00h-1FFFh ("")
+
+ E000h-E7FFh  Select 8K ROM at 8000h-9FFFh (initially 1st half of 1st 16K)
+               Bit5-0  Page_number
+ E800h-EFFFh  Select 8K ROM at A000h-BFFFh (initially 2nd half of 1st 16K)
+               Bit5-0  Page_number
+               Bit6  Select at CHR_address $0000-$0FFF 0:ROM&RAM 1:ROM
+               Bit7  Select at CHR_address $1000-$1FFF 0:ROM&RAM 1:ROM
+ F000h-F7FFh  Select 8K ROM at C000h-DFFFh (initially 1st half of last 16K)
+               Bit5-0  Page_number
+ N/A          Fixed  8K ROM at E000h-FFFFh (always    2nd half of last 16K)
+
+CPU Memmory Bank
+ cpu address|rom address    |page|task
+ $8000-$9fff|0x02000-0x03fff|1   |write 0x2aaa
+ $a000-$bfff|0x04000-0x05fff|2   |write 0x5555
+ $c000-$dfff|0x02000*n      |n   |write area
+ $e000-$ffff|末尾           |fix |boot area
+
+PPU Memmory Bank
+ ppu address|rom address    |page|task
+ $0000-$03ff|0x02800-0x02bff|0x0a|write 0x2aaa
+ $0400-$07ff|0x05400-0x057ff|0x15|write 0x5555
+ $0800-$0bff|未使用
+ $0c00-$0fff|未使用
+ $1000-$1FFF|0x1000*n       |n   |write area
+*/
+board <- {
+	mappernum = 19, vram_mirrorfind = false,
+	cpu = {banksize = 0x2000, maxsize = 4 * mega},
+	ppu = {banksize = 0x0400, maxsize = 4 * mega},
+};
+function initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_command(d, 0x2aaa, 0x8000, cpu_banksize);
+	cpu_command(d, 0x5555, 0xa000, cpu_banksize);
+	cpu_write(d, 0xe000, 1);
+	cpu_write(d, 0xe800, 2);
+
+	ppu_command(d, 0x2aaa, 0x0000, ppu_banksize);
+	ppu_command(d, 0x5555, 0x0400, ppu_banksize);
+	cpu_write(d, 0x8000, 0x0a);
+	cpu_write(d, 0x8800, 0x15);
+}
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 1; i += 1){
+		cpu_write(d, 0xf000, i);
+		cpu_program(d, 0xc000, cpu_banksize);
+	}
+	cpu_program(d, 0xe000, cpu_banksize)
+}
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	for(local i = start; i < end; i += 4){
+		cpu_write(d, 0xa000, i);
+		cpu_write(d, 0xa800, i | 1);
+		cpu_write(d, 0xb000, i | 2);
+		cpu_write(d, 0xb800, i | 3);
+		ppu_program(d, 0x1000, ppu_banksize * 4);
+	}
+}

--- a/_nrom_wx.af
+++ b/_nrom_wx.af
@@ -1,0 +1,44 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-202.html
+board <- {
+	mappernum = 0, ppu_ramfind = false, vram_mirrorfind = true,
+	cpu_rom = {
+		size_base = 0x8000, size_max = 0x8000,
+		banksize = 0x4000
+	},
+	ppu_rom = {
+		size_base = 0x2000, size_max = 0x2000,
+		banksize = 0x2000
+	}
+};
+
+function cpu_dump(d, pagesize, banksize)
+{
+	cpu_read(d, 0x8000, 0x4000);
+	cpu_read(d, 0xc000, 0x4000);
+}
+function ppu_dump(d, pagesize, banksize)
+{
+	ppu_read(d, 0, banksize);
+}
+
+function program_initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_command(d, 0, 0x8000, cpu_banksize);
+	cpu_command(d, 0x02aa, 0xc000, cpu_banksize);
+	cpu_command(d, 0x0555, 0xc000, cpu_banksize);
+
+	ppu_command(d, 0x0000, 0, 0x0000);
+	ppu_command(d, 0x02aa, 0, 0x1000);
+	ppu_command(d, 0x0555, 0, 0x1000);
+}
+
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	cpu_program(d, 0x8000, cpu_banksize);
+	cpu_program(d, 0xc000, cpu_banksize);
+}
+
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	ppu_program(d, 0x0000, ppu_banksize);
+}

--- a/_tc0190.ad
+++ b/_tc0190.ad
@@ -1,0 +1,60 @@
+// From http://bakutendo.blog87.fc2.com/blog-entry-189.html
+// とtc0690（マッパ３３）
+/*
+TAITO#33 TC0190/TC0350/TC0690 FLASH MEMORY WRITE
+PRGROM:4M[MAX] CHRROM:4M[MAX]?
+
+TC0690
+ キャプテンセイバー
+ ジェットソン
+ バブルボブル２
+
+TC0350
+ ドンドコドン２
+
+CPU Memmory Bank
+ cpu address|rom address    |page|task
+ $8000-$9fff|0x02000-0x03fff|1   |write 0x2aaa
+ $a000-$bfff|0x02000*n      |n   |write area
+ $c000-$ffff|末尾           |fix |boot area & write 0x5555
+
+PPU Memmory Bank
+ ppu address|rom address    |page|task
+ $0000-$0fff|0x1000*n       |n   |write area
+ $1000-$13ff|0x02800-0x02bff|0x0a|write 0x2aaa
+ $1400-$17ff|0x05400-0x057ff|0x15|write 0x5555
+ $1800-$1bff|未使用         |    |
+ $1c00-$1FFF|未使用         |    |
+*/
+board <- {
+	mappernum = 33,  vram_mirrorfind = false,
+	cpu = {banksize = 0x2000, maxsize = 2 * mega},
+	ppu = {banksize = 0x0800, maxsize = 2 * mega},
+};
+function initalize(d, cpu_banksize, ppu_banksize)
+{
+	cpu_command(d, 0x2aaa, 0x8000, cpu_banksize);
+	cpu_command(d, 0x5555, 0xc000, cpu_banksize);
+	cpu_write(d, 0x8000, 1);
+
+	ppu_command(d, 0x2aaa, 0x1000, ppu_banksize);
+	ppu_command(d, 0x5555, 0x1400, ppu_banksize);
+	cpu_write(d, 0xa000, 0x0a);
+	cpu_write(d, 0xa001, 0x15);
+}
+function cpu_transfer(d, start, end, cpu_banksize)
+{
+	for(local i = start; i < end - 2; i += 1){
+		cpu_write(d, 0x8001, i);
+		cpu_program(d, 0xa000, cpu_banksize);
+	}
+	cpu_program(d, 0xc000, cpu_banksize * 2);
+}
+function ppu_transfer(d, start, end, ppu_banksize)
+{
+	for(local i = start; i < end; i += 2){
+		cpu_write(d, 0x8002, i);
+		cpu_write(d, 0x8003, i | 1);
+		ppu_program(d, 0x0000, ppu_banksize * 2);
+	}
+}


### PR DESCRIPTION
Add New Scripts:
- Mapper 0  / _nrom_wx.af
- Mapper 5 / _mdc5.af
- Mapper 16 / _lz93d50#16.ad
- Mapper 16 / _lz93d50#16write.ad
- Mapper 19 / _namcot163.ad
- Mapper 33 / _tc0190.ad
- Mapper 69 / _Sunsoft5.ad
- Mapper 70 / _bandai_70.ud
- Mapper 185 / _mapper_185.ad

This also adds a link in the README to the authors [how to write mapper scripts](http://unagi.osdn.jp/cgi-bin/hiki/hiki.cgi?how+to+describe+mapper+scripts) wiki entry, might be good to backup here in the README itself.